### PR TITLE
Adapter registration supports a block

### DIFF
--- a/lib/web_console/repl.rb
+++ b/lib/web_console/repl.rb
@@ -19,9 +19,13 @@ module WebConsole
     #
     # For example, adapter named +WebConsole::REPL::IRB+ will derive the
     # adaptee constant to +::IRB+.
+    #
+    # If a block is given, it would be evaluated right after the adapter
+    # registration.
     def register_adapter(adapter_class, adaptee_constant = nil)
       adaptee_constant ||= derive_adaptee_constant_from(adapter_class)
       adapters[adaptee_constant] = adapter_class
+      yield if block_given?
     end
 
     # Get the default adapter for the given application.

--- a/lib/web_console/repl/irb.rb
+++ b/lib/web_console/repl/irb.rb
@@ -11,22 +11,6 @@ module WebConsole
     #
     # Adapter for the IRB REPL, which is the default Ruby on Rails console.
     class IRB
-      # Freedom patch the reference Irb class so that the unqualified prints go
-      # to the context's output method.
-      class ::IRB::Irb
-        private
-          def print(*args)
-            @context.instance_variable_get(:@output_method).print(*args)
-          end
-
-          def printf(str, *args)
-            @context.instance_variable_get(:@output_method).print(str % args)
-          end
-      end
-
-      # Include all of the rails console helpers in the IRB session.
-      ::IRB::ExtendCommandBundle.send :include, Rails::ConsoleMethods
-
       class StringIOInputMethod < ::IRB::InputMethod
         def initialize(io)
           @io = io
@@ -98,6 +82,22 @@ module WebConsole
         end
     end
 
-    register_adapter IRB
+    register_adapter IRB do
+      # Freedom patch the reference Irb class so that the unqualified prints go
+      # to the context's output method.
+      class ::IRB::Irb
+        private
+          def print(*args)
+            @context.instance_variable_get(:@output_method).print(*args)
+          end
+
+          def printf(str, *args)
+            @context.instance_variable_get(:@output_method).print(str % args)
+          end
+      end
+
+      # Include all of the rails console helpers in the IRB session.
+      ::IRB::ExtendCommandBundle.send :include, Rails::ConsoleMethods
+    end
   end
 end


### PR DESCRIPTION
For the IRB adapter we had to do monkey patching and rails console helper methods inclusion. Both of those were a one-off tasks, that were placed kinda funky in the code.

If `WebConsole::REPL.register_adapter` supports a block, that would be executed right after the initialization, those blocks would be prefect locations for one-off tasks, like the one above.
