### PR TITLE
Update Docker instructions for 0.5.3 and avoid `git clone`

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -129,8 +129,7 @@ If you just want to try the web-console, without having to go through the
 trouble of installing it, we provide a [Docker] container that does that for
 you.
 
-To try it, install [Docker], clone the project and run the following snippet in
-the git root directory.
+To try it, install [Docker] first and then run the following snippet in your shell.
 
 ```bash
 sudo docker build -t gsamokovarov/web-console github.com/gsamokovarov/web-console && sudo docker run -i -t !#:3


### PR DESCRIPTION
Since 0.5.3 Docker listens on a socket which is only readable/writeable by `root`, all `docker` commands need to be run as a superuser.

It is also possible to build from GitHub without cloning so this pull includes that change as well.

Tested and works on Ubuntu 13.04 with lxc-docker 0.5.3 from official Launchpad PPA.
