### PR TITLE
Disable autofocus when initializing the console

### DIFF
--- a/lib/action_dispatch/templates/rescues/_web_console.html.erb
+++ b/lib/action_dispatch/templates/rescues/_web_console.html.erb
@@ -164,7 +164,6 @@
         this.inner = container.getElementsByClassName('console-inner')[0];
         this.clipboard = document.getElementById('clipboard');
         this.newPromptBox();
-        this.focus();
       };
 
       REPLConsole.prototype.focus = function() {


### PR DESCRIPTION
According to issues #65 and #85, autofocusing the console is quite annoying. 
